### PR TITLE
Make parser DFA deterministic

### DIFF
--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -265,7 +265,6 @@ class ParserTestConflicts(unittest.TestCase):
             self.assertTrue(False, msg='Parser did not detect shift/reduce conflict')
 
         except GrammarError as e:
-            # The length is not deterministic
             self.assertEqual(len(e.conflicts), 8)
             for c in e.conflicts:
                 self.assertTrue(c.is_shift_reduce())


### PR DESCRIPTION
Ill-ordering in tuple representation of LR closure made closure with same elements not equal and lead to non-deterministic DFA's. This has been fixed by wrapping closure in a class that keeps the tuple in a deterministic order.