### PR TITLE
Regexp parser

### DIFF
--- a/compyl/Lexer/RegExp.py
+++ b/compyl/Lexer/RegExp.py
@@ -1,6 +1,5 @@
 import copy
 import re
-from collections import OrderedDict
 
 from compyl.Lexer.IntervalOperations import inverse_intervals_list, merge_intervals, get_minimal_covering_intervals
 
@@ -184,7 +183,7 @@ class RegexpTree:
 
     def print_regexp(self):
         """
-        Return the corresponding regexp as string
+        Return the corresponding regexp as string for debugging purpose
         """
         if self.type == 'single':
             if self.min_ascii == self.max_ascii:
@@ -216,425 +215,9 @@ def format_regexp(regexp):
     return Parser.parse(regexp)
 
 
-def regexp_to_regexp_tree_list(regexp, pos=0):
-    """
-    Parse a regular expression and return it as a list of RegexpTree objects
-    """
-    nodes_list = []
-    regexp_length = len(regexp)
-
-    while pos < regexp_length:
-        new_nodes, new_pos = get_next_regexp_tree_token(regexp, pos=pos, nodes_list=nodes_list)
-        pos = new_pos
-        nodes_list += new_nodes
-
-    return nodes_list
-
-
-def get_next_regexp_tree_token(regexp, pos=0, nodes_list=None):
-    """
-    Get the next regexp element(s) and return them as well as the new position in the string.
-    Note: This return the next token based on a single lookahead. By example "a*c" will only see a, two call will be
-          needed to see a*, thus it is needed to pass a nodes_list to be able to mutate the last element if, by example,
-          "*" or "+" are seen
-    Note2: When encountering |, the method parses the rest of the regexp since it needs the following tokens to form the
-           union
-    :param regexp: The regexp as string
-    :param pos: the position where to start
-    :param nodes_list: Previous tokens processed in the regexp, if a look-behind is necessary, the last element will be
-                       poped out, mutating the nodes_list and using the poped node to build a new node.
-    :return: The list of new RegexpTree nodes and the next position
-    """
-    # Will store the node if a single node is to be returned
-    node = None
-
-    if regexp[pos] == "\\":
-        intervals, pos = get_escaped_ascii(regexp, pos + 1)
-        node = reduce_interval_list_to_regexp_tree_union(intervals)
-        nodes = [node]
-
-    elif regexp[pos] == "[":
-        end_pos = find_next_non_escaped_char("]", regexp, beg=pos + 1)
-
-        if end_pos:
-            node = get_regexptree_union_from_set(regexp[pos + 1:end_pos])
-            pos += end_pos - pos + 1
-        else:
-            raise RegexpParsingException("bad set syntax, expected ]")
-
-        nodes = [node]
-
-    elif regexp[pos] == "(":
-        end_pos = find_matching_closing_parenthesis(regexp, beg=pos + 1)
-        sub_regexp = regexp[pos + 1:end_pos]
-
-        node = format_regexp(sub_regexp)
-        pos += end_pos - pos + 1
-        nodes = [node]
-
-    elif regexp[pos] == "*":
-        node = RegexpTree(
-            'kleene',
-            nodes_list.pop()
-        )
-        pos += 1
-        nodes = [node]
-
-    elif regexp[pos] == "+":
-        first_occurence = nodes_list.pop()
-        kleene_component = RegexpTree('kleene', copy.deepcopy(first_occurence))
-        first_occurence.extend(kleene_component)
-        pos += 1
-        nodes = [first_occurence]
-
-    elif regexp[pos] == "?":
-        try:
-            node_to_repeat = nodes_list.pop()
-        except IndexError:
-            raise RegexpParsingException("bad syntax, '?' without token")
-
-        node = repeat_regexptree(node_to_repeat, 0, 1)
-        pos += 1
-
-        nodes = [node]
-
-    elif regexp[pos] == "{":
-        end_pos = regexp.find("}", pos + 1)
-        min_max = regexp[pos + 1: end_pos].split(',')
-        length = len(min_max)
-
-        if length == 1:
-            min = max = int(min_max[0])
-
-        elif length == 2:
-            min = int(min_max[0])
-            max = int(min_max[1])
-
-        else:
-            raise RegexpParsingException("bad syntax for min-max repetition")
-
-        if 0 <= min <= max and max > 0:
-            try:
-                node_to_repeat = nodes_list.pop()
-            except IndexError:
-                raise RegexpParsingException("bad syntax, repetition without token")
-
-            node = repeat_regexptree(node_to_repeat, min, max)
-            pos += end_pos - pos + 1
-
-        else:
-            RegexpParsingException("bad interval for min-max repetition")
-
-        nodes = [node]
-
-    elif regexp[pos] == "|":
-        pos += 1
-
-        # Since we need the next token to create the union RegexpTree, we parse the rest of the regexp and later we
-        # form the union and return the whole list
-        next_nodes = regexp_to_regexp_tree_list(regexp, pos=pos)
-
-        try:
-            union_fst = nodes_list.pop()
-            union_snd = next_nodes.pop(0)
-        except IndexError:
-            raise RegexpParsingException("bad syntax, unexpected |")
-
-        # We just parsed the whole regexp, thus we are done
-        pos = len(regexp)
-
-        node = RegexpTree(
-            'union',
-            union_fst,
-            union_snd,
-        )
-
-        nodes = [node] + next_nodes
-
-    elif regexp[pos] == ".":
-        node = RegexpTree(
-            'union',
-            RegexpTree('single', 0, 9),
-            RegexpTree('single', 11, 255)
-        )
-        pos += 1
-        nodes = [node]
-
-    elif regexp[pos] == "_":
-        node = RegexpTree('single', 0, 255)
-        pos += 1
-        nodes = [node]
-
-    else:
-        char = ord(regexp[pos])
-        node = RegexpTree('single', char, char)
-        pos += 1
-        nodes = [node]
-
-    return nodes, pos
-
-
-def get_escaped_ascii(regexp, pos):
-    """
-    Return the ascii values of an escaped char, i.e. preceded by a \
-    In particular, regexp should be build using raw strings, thus we need to implement the python built-in escape
-    sequences
-    We also implement special sequences with the same convention as they are in the re Python module
-    The function has two return values. The first is a list of intervals of ascii values, the second is the new position
-    """
-    escape = {"a": "\a",
-              "b": "\b",
-              "f": "\f",
-              "n": "\n",
-              "r": "\r",
-              "t": "\t",
-              "v": "\v"
-              }
-
-    char = regexp[pos]
-
-    if char in escape:
-        ascii = ord(escape[char])
-        ascii_list = [(ascii, ascii)]
-        new_pos = pos + 1
-
-    elif char == "x":
-        # Hexadecimal
-        try:
-            ascii = int(regexp[pos + 1: pos + 3], 16)
-            ascii_list = [(ascii, ascii)]
-            new_pos = pos + 3
-        except (ValueError, IndexError):
-            raise RegexpParsingException("bad hexadecimal syntax, must be of format \\xhh")
-
-    elif char == "s":
-        # Whitespaces
-        ascii_list = [(9, 13), (32, 32)]
-        new_pos = pos + 1
-
-    elif char == "S":
-        # Non-whitespaces
-        ascii_list = [(0, 8), (14, 31), (33, 255)]
-        new_pos = pos + 1
-
-    elif char == "w":
-        # Alphanumerical and underscore
-        ascii_list = [(48, 57), (65, 90), (95, 95), (97, 122)]
-        new_pos = pos + 1
-
-    elif char == "W":
-        # Non-alphanumerical-or-underscore
-        ascii_list = [(0, 47), (58, 64), (91, 94), (96, 96), (123, 255)]
-        new_pos = pos + 1
-
-    elif char == "d":
-        # Digits
-        ascii_list = [(48, 57)]
-        new_pos = pos + 1
-
-    elif char == "D":
-        # Non-digits
-        ascii_list = [(0, 47), (58, 255)]
-        new_pos = pos + 1
-
-    else:
-        ascii = ord(char)
-        ascii_list = [(ascii, ascii)]
-        new_pos = pos + 1
-
-    return ascii_list, new_pos
-
-
-def get_regexptree_union_from_set(inner_set):
-    """
-    Given the inner part of a set ([...]) in a regexp, return the corresponding RegexpTree object
-    """
-    if inner_set:
-        length = len(inner_set)
-        pos = 0
-        intervals = []
-        invert_set = False
-
-        if inner_set[pos] == "^":
-            invert_set = True
-            pos += 1
-
-        while pos < length:
-            if inner_set[pos] == "\\":
-                escaped_intervals, pos = get_escaped_ascii(inner_set, pos)
-                intervals.extend(escaped_intervals)
-
-            elif inner_set[pos] == "-":
-                try:
-                    previous = intervals.pop()
-                except IndexError:
-                    raise RegexpParsingException("bad syntax for range in set, unexpected -")
-
-                if previous[0] == previous[1]:
-                    min = previous[0]
-                else:
-                    raise RegexpParsingException("bad syntax for range in set, unexpected -")
-
-                if inner_set[pos + 1] == "\\":
-                    max = ord(inner_set[pos + 2])
-                    pos += 3
-
-                else:
-                    max = ord(inner_set[pos + 1])
-                    pos += 2
-
-                if min <= max:
-                    intervals.append((min, max))
-                else:
-                    raise RegexpParsingException("bad syntax for range x-y, x ascii exceeds y ascii")
-
-            else:
-                ascii = ord(inner_set[pos])
-                intervals.append((ascii, ascii))
-                pos += 1
-
-        # Sort and merge overlapping intervals
-        intervals = merge_intervals(intervals)
-
-        if invert_set:
-            intervals = inverse_intervals_list(intervals)
-
-        return reduce_interval_list_to_regexp_tree_union(intervals)
-
-    else:
-        raise RegexpParsingException("bad set, set cannot be empty")
-
-
-def find_matching_closing_parenthesis(string, beg=0):
-    """
-    Find the closing parenthesis starting at 'beg' in a string and return its position. Return None if there is none.
-    The character at position 'beg' does not have to be the opening parenthesis.
-    """
-    depth = 0
-    pos = beg
-
-    while True:
-        try:
-            char = string[pos]
-        except IndexError:
-            return None
-
-        if char == "(":
-            depth += 1
-            pos += 1
-
-        elif char == ")":
-            if depth == 0:
-                return pos
-
-            else:
-                pos += 1
-                depth -= 1
-
-        else:
-            pos += 1
-
-
-def find_next_non_escaped_char(char, string, beg=0):
-    """
-    Find the next non escaped (not preceded with \) of the given char (string even though intended to be a single char)
-    and return its position. Return None if no match
-    """
-    non_escaped_pattern = re.compile(r"(?<!\\)" + char)
-    match = non_escaped_pattern.search(string, beg)
-
-    if match:
-        return match.start()
-    else:
-        return None
-
-
-def repeat_regexptree(node, min, max):
-    """
-    Given a pattern as a RegexpTree (node), return a RegexpTree representing the pattern repeated from min to max times
-    """
-    if min > 0:
-        first = copy.deepcopy(node)
-        last = first
-        min -= 1
-        max -= 1
-
-    elif max < float('inf'):
-        last = copy.deepcopy(node)
-        first = RegexpTree(
-            'union',
-            None,
-            last
-        )
-        max -= 1
-
-    else:
-        return RegexpTree(
-            'kleene',
-            copy.deepcopy(node)
-        )
-
-    while min > 0:
-        extension = copy.deepcopy(node)
-        last.extend(extension)
-        last = extension
-        min -= 1
-        max -= 1
-
-    while 0 < max < float('inf'):
-        extension_snd = copy.deepcopy(node)
-        extension = RegexpTree(
-            'union',
-            None,
-            extension_snd
-        )
-        last.extend(extension)
-        last = extension_snd
-
-        max -= 1
-
-    if max == float('inf'):
-        first.extend(
-            RegexpTree('kleene', copy.deepcopy(node))
-        )
-
-    return first
-
-
-def reduce_interval_list_to_regexp_tree_union(intervals, next=None):
-    """
-    Given a list of intervals of ascii values, return the RegexpTree corresponding to the union of all those intervals
-    """
-    length = len(intervals)
-
-    if length == 0:
-        return None
-
-    if length == 1:
-        return RegexpTree(
-            'single',
-            intervals[0][0],
-            intervals[0][1],
-            next
-        )
-
-    else:
-        return RegexpTree(
-            'union',
-            RegexpTree(
-                'single',
-                intervals[0][0],
-                intervals[0][1]
-            ),
-            reduce_interval_list_to_regexp_tree_union(intervals[1:]),
-            next
-        )
-
-
 # ======================================================================================================================
 # RegExp Dummy Parser
 # ======================================================================================================================
-
 
 class Token:
     pass
@@ -782,6 +365,60 @@ class Repetition(Token):
     def __init__(self, min, max):
         self.min = min
         self.max = max
+
+    def repeat_regexptree(self, node):
+        """
+        Given a pattern as a RegexpTree (node), return a RegexpTree representing the pattern repeated from min to max times
+        """
+        min = self.min
+        max = self.max
+
+        if min > 0:
+            first = copy.deepcopy(node)
+            last = first
+            min -= 1
+            max -= 1
+
+        elif max < float('inf'):
+            last = copy.deepcopy(node)
+            first = RegexpTree(
+                'union',
+                None,
+                last
+            )
+            max -= 1
+
+        else:
+            return RegexpTree(
+                'kleene',
+                copy.deepcopy(node)
+            )
+
+        while min > 0:
+            extension = copy.deepcopy(node)
+            last.extend(extension)
+            last = extension
+            min -= 1
+            max -= 1
+
+        while 0 < max < float('inf'):
+            extension_snd = copy.deepcopy(node)
+            extension = RegexpTree(
+                'union',
+                None,
+                extension_snd
+            )
+            last.extend(extension)
+            last = extension_snd
+
+            max -= 1
+
+        if max == float('inf'):
+            first.extend(
+                RegexpTree('kleene', copy.deepcopy(node))
+            )
+
+        return first
 
 
 class RepetitionExact(Repetition):
@@ -937,7 +574,7 @@ class Parser:
                     raise RegexpParsingException
 
                 regexp_nodes.append(
-                    repeat_regexptree(repeated_node, tk.min, tk.max)
+                    tk.repeat_regexptree(repeated_node)
                 )
 
             elif isinstance(tk, Union):
@@ -955,4 +592,3 @@ class Parser:
             return cls._concat_nodes(regexp_nodes)
         else:
             raise RegexpParsingException
-

--- a/compyl/Lexer/RegExp.py
+++ b/compyl/Lexer/RegExp.py
@@ -100,22 +100,22 @@ class RegexpTree:
                 'single',
                 self.min_ascii,
                 self.max_ascii,
-                self.next.__deepcopy__({}) if self.next else None
+                copy.deepcopy(self.next)
             )
 
         elif self.type == 'union':
             dup = RegexpTree(
                 'union',
-                self.fst.__deepcopy__({}),
-                self.snd.__deepcopy__({}),
-                self.next.__deepcopy__({}) if self.next else None
+                copy.deepcopy(self.fst),
+                copy.deepcopy(self.snd),
+                copy.deepcopy(self.next)
             )
 
         elif self.type == 'kleene':
             dup = RegexpTree(
                 'kleene',
-                self.pattern.__deepcopy__({}),
-                self.next.__deepcopy__({}) if self.next else None
+                copy.deepcopy(self.pattern),
+                copy.deepcopy(self.next)
             )
 
         return dup

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -268,7 +268,7 @@ class LexerTestRegexp(unittest.TestCase):
         self.assertEqual(tk.value, 'aaa')
         self.assertRaises(LexerError, lexer.lex)
 
-    def test_match_amount(self):
+    def test_match_min_max_amount(self):
         rules = [
             (r'a{2, 3}x', 'THREE_A')
         ]
@@ -532,7 +532,7 @@ class LexerTestBuild(unittest.TestCase):
 
     def test_regexp_minimum_length(self):
         rules = [
-            ('a*', 'A')
+            (r'a*', 'A')
         ]
 
         lexer = Lexer(rules=rules)
@@ -541,7 +541,7 @@ class LexerTestBuild(unittest.TestCase):
 
     def test_special_action_choices(self):
         rules = [
-            ('a', 'A', 'foo')
+            (r'a', 'A', 'foo')
         ]
 
         lexer = Lexer(rules=rules)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -5,6 +5,9 @@ from compyl.Lexer.Lexer import Lexer, LexerError
 from compyl.Lexer.FiniteAutomaton import FiniteAutomatonError
 
 
+FAIL = False
+
+
 def get_token_stream(lexer, buffer):
     lexer.read(buffer)
     tk_list = []
@@ -24,6 +27,14 @@ def get_token_stream_types(lexer, buffer):
 
 def get_token_stream_values(lexer, buffer):
     return [tk.value for tk in get_token_stream(lexer, buffer)]
+
+
+def test_regexp_on_buffer(regexp, buffer):
+    rules = [(regexp, 'placeholder')]
+    lexer = Lexer(rules=rules)
+    lexer.build()
+
+    return get_token_stream_values(lexer, buffer)
 
 
 class LexerTestBasic(unittest.TestCase):
@@ -417,7 +428,86 @@ class LexerTestRegexp(unittest.TestCase):
 class LexerTestRegexpPriority(unittest.TestCase):
 
     def test_priority(self):
-        raise NotImplementedError
+        """
+        Challenge the RegExp module on various corner case of regexp operation priority
+        """
+
+        expected_rule_buffer_outputs = [
+            (r'abc|def', 'abc', ['abc']),
+            (r'abc|def', 'def', ['def']),
+            (r'abc|def', 'abdef', FAIL),
+            (r'ab(c|d)ef', 'abcef', ['abcef']),
+            (r'ab(c|d)ef', 'abc', FAIL),
+            (r'ab(c|d)ef', 'def', FAIL),
+            (r'a|b+', 'a', ['a']),
+            (r'a|b+', 'b', ['b']),
+            (r'a|b+', 'bb', ['bb']),
+            (r'a|b+', 'bbb', ['bbb']),
+            (r'a|b+', 'aa', ['a', 'a']),
+            (r'a+|b+', 'aaa', ['aaa']),
+            (r'a+|b+', 'bb', ['bb']),
+            (r'a+|b+', 'aabb', ['aa', 'bb']),
+            (r'(a|b)+', 'a', ['a']),
+            (r'(a|b)+', 'b', ['b']),
+            (r'(a|b)+', 'aba', ['aba']),
+            (r'ab{1,3}', 'ab', ['ab']),
+            (r'ab{1,3}', 'abb', ['abb']),
+            (r'ab{1,3}', 'abbb', ['abbb']),
+            (r'ab{1,3}', 'abbbb', FAIL),
+            (r'(a|b){1,2}', 'ab', ['ab']),
+            (r'(a|b){1,2}', 'ba', ['ba']),
+            (r'(a|b){1,2}', 'b', ['b']),
+            (r'(a|b){1,2}', 'aaa', ['aa', 'a']),
+            (r'a{2}+', 'aa', ['aa']),
+            (r'a{2}+', 'aaaa', ['aaaa']),
+            (r'a+{2}', 'aa', ['aa']),
+            (r'a+{2}', 'aaa', ['aaa']),
+            (r'a+{2}', 'a', FAIL),
+            (r'(a*b)+', 'bbabaab', ['bbabaab']),
+            (r'[a-z][A-Z]+', 'xXX', ['xXX']),
+            (r'[a-z][A-Z]+', 'xXxXX', ['xX', 'xXX']),
+            (r'([a-z][A-Z])+', 'xXxX', ['xXxX']),
+            (r'([a-z][A-Z])+', 'xXX', FAIL),
+            (r'([a-z][A-Z])+', 'XxX', FAIL),
+            (r'a([bc]d)*', 'abd', ['abd']),
+            (r'a([bc]d)*', 'a', ['a']),
+            (r'a([bc]d)*', 'abdcdbd', ['abdcdbd']),
+            (r'a([bc]d)*', 'abdacdbd', ['abd', 'acdbd']),
+            (r'a([bc]d)*', 'add', FAIL),
+            (r'a([bc]d)*', 'abc', FAIL),
+            (r'a|b|c', 'a', ['a']),
+            (r'a|b|c', 'b', ['b']),
+            (r'a|b|c', 'c', ['c']),
+            (r'a|b|c', 'ac', ['a', 'c']),
+            (r'(a|b)|c', 'a', ['a']),
+            (r'(a|b)|c', 'b', ['b']),
+            (r'(a|b)|c', 'c', ['c']),
+            (r'(a|b)|c', 'ac', ['a', 'c']),
+            (r'xa?|bc', 'x', ['x']),
+            (r'xa?|bc', 'xa', ['xa']),
+            (r'xa?|bc', 'bc', ['bc']),
+            (r'xa?|bc', 'xbc', ['x', 'bc']),
+            (r'[^\W]\++(j|l?)?', 'a+', ['a+']),
+            (r'[^\W]\++(j|l?)?', 'b++j', ['b++j']),
+            (r'[^\W]\++(j|l?)?', 'c+++l', ['c+++l']),
+            (r'[^\W]\++(j|l?)?', 'a+a+', ['a+', 'a+']),
+            (r'[^\W]\++(j|l?)?', 'a+ja+', ['a+j', 'a+']),
+            (r'[^\W]\++(j|l?)?', '$+j', FAIL),
+            (r'[^\W]\++(j|l?)?', 'w+jl', FAIL),
+        ]
+
+        for rules, buffer, expected in expected_rule_buffer_outputs:
+            if expected is not FAIL:
+                self.assertEqual(
+                    test_regexp_on_buffer(rules, buffer),
+                    expected
+                )
+            else:
+                self.assertRaises(
+                    LexerError,
+                    test_regexp_on_buffer, rules, buffer
+                )
+
 
 
 class LexerTestTerminalAction(unittest.TestCase):

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -573,5 +573,21 @@ class ParserTestReset(unittest.TestCase):
         self.assertEqual('success', parser.end())
 
 
+class ParserTestSave(ParserTestBasic):
+    """
+    Rerun the tests from LexerTestBasic but by saving and loading the created lexer before tests
+    """
+    parser_filename = "test_parser_save.p"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.parser.save(cls.parser_filename)
+
+    def tearDown(self):
+        self.__class__.parser = Parser.load(self.parser_filename)
+
+
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Rebuilt RegExp module.

Now use a `re` based dummy lexer-parser to parse regexps. This is no longer one-pass, but it is more maintainable and fixes priority or operation issues.